### PR TITLE
adding changes for supporting Moto transactions

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -124,6 +124,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     public static final String SPLIT_SETTLEMENT_DATA_ITEM = "splitSettlementDataItem";
     public static final String PROPERTY_RECURRING_TYPE = "recurringType";
     public static final String PROPERTY_CAPTURE_DELAY_HOURS = "captureDelayHours";
+    public static final String PROPERTY_CUSTOMER_SUPPORT_REQUEST = "customerSupportRequest";
     /**
      * Cont auth disabled validation on adyens side (no cvc required). We practically tell them that the payment data is valid.
      * Should be given as "true" or "false".

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/PaymentInfoMappingService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/PaymentInfoMappingService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.jooq.tools.StringUtils;
 import org.killbill.billing.account.api.AccountData;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.plugin.adyen.client.AdyenConfigProperties;
@@ -290,6 +291,12 @@ public abstract class PaymentInfoMappingService {
             contract = "RECURRING";
         }
         paymentInfo.setContract(contract);
+
+        final String customerSupportRequest = PluginProperties.findPluginPropertyValue(PROPERTY_CUSTOMER_SUPPORT_REQUEST, properties);
+        if (!StringUtils.isBlank(customerSupportRequest) && Boolean.valueOf(customerSupportRequest)) {
+            paymentInfo.setShopperInteraction("Moto");
+            return;
+        }
 
         final String selectedBrand = PluginProperties.findPluginPropertyValue(PROPERTY_SELECTED_BRAND, properties);
         final String contAuthProperty = PluginProperties.findPluginPropertyValue(PROPERTY_CONTINUOUS_AUTHENTICATION, properties);


### PR DESCRIPTION
Adding changes for supporting Moto transactions using API.
`Using Adyen's Mail Order / Telephone Order (MOTO) your shopper can make a call to a call center or send a coupon/voucher to communicate their credit card number initiating an offline transaction.` 
